### PR TITLE
GET /api/comments」にリクエストを投げたらコメント一覧が返ってくるAPIのテスト

### DIFF
--- a/test/app/api/comments/getComments.test.js
+++ b/test/app/api/comments/getComments.test.js
@@ -1,0 +1,22 @@
+const assert = require('power-assert');
+const requestHelper = require('../../../helper/requestHelper');
+
+describe('test 「GET /api/comments」', () => {
+    it('returns comments in resopnse.body', async () => {
+        const response = await requestHelper.request({
+            method: 'get',
+            endPoint: '/api/comments',
+            statusCode: 200
+        });
+
+        const comments = response.body;
+        assert.ok(Array.isArray(comments));
+        todos.forEach((comment) => {
+            assert.strictEqual(typeof comment.id, 'number');
+            assert.strictEqual(typeof comment.username, 'string');
+            assert.strictEqual(typeof comment.body, 'string');
+            assert.strictEqual(typeof comment.createdAt, 'string');
+            assert.strictEqual(typeof comment.updatedAt, 'string');
+        });
+    });
+}); 

--- a/test/app/api/comments/getComments.test.js
+++ b/test/app/api/comments/getComments.test.js
@@ -11,7 +11,7 @@ describe('test 「GET /api/comments」', () => {
 
         const comments = response.body;
         assert.ok(Array.isArray(comments));
-        todos.forEach((comment) => {
+        comments.forEach((comment) => {
             assert.strictEqual(typeof comment.id, 'number');
             assert.strictEqual(typeof comment.username, 'string');
             assert.strictEqual(typeof comment.body, 'string');

--- a/test/helper/requestHelper.js
+++ b/test/helper/requestHelper.js
@@ -1,5 +1,5 @@
 const request = require('supertest');
-const app = ('../../app');
+const app = require('../../app');
 
 module.exports = {
     request: ({ method, endPoint, statusCode }) => {

--- a/test/helper/requestHelper.js
+++ b/test/helper/requestHelper.js
@@ -1,0 +1,12 @@
+const request = require('supertest');
+const app = ('../../app');
+
+module.exports = {
+    request: ({ method, endPoint, statusCode }) => {
+        // 詳しくはsupertestのドキュメントを参考にする
+        return request(app)[method](endPoint)
+            .set('Accept', 'application/json')
+            .expect('Content-Type', /application\/json/)
+            .expect(statusCode);
+    }
+};


### PR DESCRIPTION
以下Issuesの内容を実装しました！
#9 

ご確認よろしくお願いします！

1つ質問あるのですが、よろしいでしょうか？

modelのfindAllのテストコードでは、取得したコメント一覧にて、プロパティとプロパティ値が正しいことを確認していました。
```
comments.forEach(comment => {
     assert.deepStrictEqual({ ...comment }, {
          id: comment.id,
          username: comment.username,
          body: comment.body,
          createdAt: comment.createdAt,
          updatedAt: comment.updatedAt
     });
});
```
今回のgetCommentsメソッドのAPIテストにおいては、取得したコメント一覧のプロパティの型が一致していることを確認しました。
```
comments.forEach((comment) => {
     assert.strictEqual(typeof comment.id, 'number');
     assert.strictEqual(typeof comment.username, 'string');
     assert.strictEqual(typeof comment.body, 'string');
     assert.strictEqual(typeof comment.createdAt, 'string');
     assert.strictEqual(typeof comment.updatedAt, 'string');
});
```

以上の差は、Web白熱教室でのテストコードの真似をしたためであります。
(https://tsuyopon.xyz/learning-contents/web-dev/javascript/backend/implement-the-find-all-method-in-a-model/)
(https://tsuyopon.xyz/learning-contents/web-dev/javascript/backend/create-a-test-file-for-the-get-todos-api/)

APIとmodelのメソッドにおいて取得しているものは同じなのに、テストの方法が異なっているのはなぜでしょうか？

よろしくお願いしますmm